### PR TITLE
Fix: `data-name` and `data-stack-name` with non-ASCII characters navigation issue by replacing `\W` with `\s`

### DIFF
--- a/custom-jp.md
+++ b/custom-jp.md
@@ -1,0 +1,56 @@
+<!-- .slide: data-state="hide-menubar" -->
+# Simplemenu
+### for Reveal.js
+Using custom styling
+
+---
+<!-- .slide: data-state="hide-menubar" -->
+### Table of Contents
+<ul class="menu"><ul>
+
+---
+
+<!-- .slide: data-name="1つ目の項目" -->
+## Slide 1
+A paragraph with some text and a [link](http://hakim.se).
+
+---
+
+<!-- .slide: data-stack-name="設定" -->
+## Setup
+
+----
+
+Add a header via the `barhtml` option and include your custom header markup. Change the CSS to your needs and link to it through the `csspath` option.
+
+```js []
+Reveal.initialize({
+	//...
+	simplemenu: {
+		barhtml: { 
+			header: '<div class="menubar"><a href="#"><img class="logo" src="img/logo.svg"></a><ul class="menu"></ul></div>'
+		},
+		csspath: 'css/mycustomstyle.css'
+	},
+	plugins: [ Simplemenu ]
+```
+
+----
+
+You can also move the slidenumber into the menubar by just adding a div with the class `slide-number` to it:
+
+```js []
+Reveal.initialize({
+	//...
+	simplemenu: {
+		barhtml: { 
+			header: '<div class="menubar"><a href="#"><img class="logo" src="img/logo.svg"></a><ul class="menu"></ul><div class="slide-number"></div></div>'
+		},
+		csspath: 'css/mycustomstyle.css'
+	},
+	plugins: [ Simplemenu ]
+```
+
+---
+<!-- .slide: data-state="hide-menu" -->
+#### That’s it!

--- a/demo-custom-jp.html
+++ b/demo-custom-jp.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Simplemenu for Reveal.js</title>
+    <meta name="description" content="">
+    <meta name="author" content="Martinomagnifico">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <link rel="stylesheet" href="../dist/reset.css">
+    <link rel="stylesheet" href="../dist/reveal.css">
+    <link rel="stylesheet" href="../dist/theme/white.css">
+    <link rel="stylesheet" href="../plugin/highlight/monokai.css">
+    <link rel="stylesheet" href="css/demo.css">
+</head>
+
+<body>
+    <div class="reveal"><a class="github-corner bottom" href="https://github.com/Martinomagnifico/reveal.js-simplemenu" target="blank" title="View source on GitHub">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 55 55">
+                <path fill="currentColor" d="M27.5 11.2a16.3 16.3 0 0 0-5.1 31.7c.8.2 1.1-.3 1.1-.7v-2.8c-4.5 1-5.5-2.2-5.5-2.2-.7-1.9-1.8-2.4-1.8-2.4-1.5-1 .1-1 .1-1 1.6.1 2.5 1.7 2.5 1.7 1.5 2.5 3.8 1.8 4.7 1.4.2-1 .6-1.8 1-2.2-3.5-.4-7.3-1.8-7.3-8 0-1.8.6-3.3 1.6-4.4-.1-.5-.7-2.1.2-4.4 0 0 1.4-.4 4.5 1.7a15.6 15.6 0 0 1 8.1 0c3.1-2 4.5-1.7 4.5-1.7.9 2.3.3 4 .2 4.4 1 1 1.6 2.6 1.6 4.3 0 6.3-3.8 7.7-7.4 8 .6.6 1.1 1.6 1.1 3v4.6c0 .4.3.9 1.1.7a16.3 16.3 0 0 0-5.2-31.7"></path>
+            </svg></a>
+        <div class="slides">
+            <section data-markdown="custom-jp.md" data-separator="^
+?
+---
+?
+" data-separator-vertical="^
+?
+----
+?
+" data-charset="utf-8"></section>
+        </div>
+    </div>
+    <script src="../dist/reveal.js"></script>
+    <script src="plugin/simplemenu/simplemenu.js"></script>
+    <script src="../plugin/highlight/highlight.js"></script>
+    <script src="../plugin/markdown/markdown.js"></script>
+    <script>
+        Reveal.initialize({
+            transition: "slide",
+            slideNumber: "c/t",
+            simplemenu: {
+                barhtml: {
+                    header: "<div class='menubar'><a class='logo' href='#'><img src='img/logo.svg'></a><ul class='menu'></ul><div class='slide-number'></div></div>"
+                },
+                csspath: "css/mycustomstyle.css"
+            },
+            plugins: [
+                RevealMarkdown,
+                Simplemenu,
+                RevealHighlight
+            ]
+        });
+    </script>
+</body>
+
+</html>

--- a/plugin/simplemenu/simplemenu.js
+++ b/plugin/simplemenu/simplemenu.js
@@ -211,14 +211,14 @@
 	      // If the (named) section is not a stack and does not have an ID, we need to give it one.
 	      if (!isStack(namedsection) && !namedsection.id) {
 	        // Note: Quarto will already have assigned an ID, but it may also have been done manually.
-	        namedsection.id = match.toLowerCase().replace(/\W/g, '');
+	        namedsection.id = match.toLowerCase().replace(/\s/g, '');
 	      } else if (isStack(namedsection)) {
 	        // Find the first (visible) section inside a stack.
 	        let allsects = selectionArray(namedsection, `section`);
 	        let allVisibleSects = allsects.filter(section => section.dataset.visibility != "hidden");
 	        let firstChildSection = allVisibleSects[0];
 	        if (firstChildSection && !firstChildSection.id) {
-	          firstChildSection.id = match.toLowerCase().replace(/\W/g, '');
+	          firstChildSection.id = match.toLowerCase().replace(/\s/g, '');
 	          if (namedsection.id == firstChildSection.id) {
 	            namedsection.removeAttribute('id');
 	          }
@@ -331,7 +331,7 @@
 	      const autoMenuLinks = sections.namedvisible.map(section => {
 	        let match = section.dataset[vars.matchString];
 	        let name = section.dataset.name || section.getAttribute(`name`) || section.id;
-	        let id = section.id || name.toLowerCase().replace(/\W/g, '');
+	        let id = section.id || name.toLowerCase().replace(/\s/g, '');
 	        idArray.push(id);
 	        if (vars.quarto) {
 	          id = mainArray.find(item => item.match === match).id;
@@ -361,7 +361,7 @@
 	        let linker = listItem.tagName == "a" ? listItem : listItem.querySelector('a');
 	        let linkhref = linker.getAttribute('href');
 	        if (linkhref === "#") {
-	          let newLink = listItem.dataset[vars.matchString].toLowerCase().replace(/\W/g, '');
+	          let newLink = listItem.dataset[vars.matchString].toLowerCase().replace(/\s/g, '');
 	          linker.href = `#/${newLink}`;
 	        }
 	      });


### PR DESCRIPTION
## Description

This PR addresses the issue where navigation fails when using `data-name` and `data-stack-name` with non-ASCII characters (e.g., Japanese, Chinese, Korean). 
The previous implementation used the regex `\W` to remove non-word characters when generating IDs, which incorrectly stripped non-ASCII characters. 
This PR replaces `\W` with `\s` in the ID generation, removing only whitespace and preserving non-ASCII characters. 
This allows menu links to correctly navigate to sections with non-ASCII characters in their `data-name` and `data-stack-name`.
However, I'm a bit concerned that this change could introduce some side effects. 
Please let me know if you observe any issues.

## Changes

- Replaced `/\W/g` with `/\s/g` in the following locations:
    - `namedsection.id` generation
    - `firstChildSection.id` generation
    - `autoMenuLinks` generation
    - manual menu link `href` generation

## Testing

The issue was tested with `data-name` and `data-stack-name` containing Japanese characters. Navigation now works as expected.